### PR TITLE
Add String.Equals and VB specific CompareString support

### DIFF
--- a/src/RepoDb.Core.UnitTests/QueryGroups/QueryGroupParseExpressionForStringTypeTest.cs
+++ b/src/RepoDb.Core.UnitTests/QueryGroups/QueryGroupParseExpressionForStringTypeTest.cs
@@ -75,6 +75,77 @@ public partial class QueryGroupTest
 
     #endregion
 
+    #region NotEqual (!=)
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringConstantNot()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString != "A").GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringVariableNot()
+    {
+        // Setup
+        var value = "A";
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString != value).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringClassPropertyNot()
+    {
+        // Setup
+        var value = new QueryGroupTestExpressionClass
+        {
+            PropertyString = "A"
+        };
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString != value.PropertyString).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringMethodCallNot()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString != GetStringValueForParseExpression()).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringVariableMethodCallNot()
+    {
+        // Setup
+        var value = GetStringValueForParseExpression();
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString != value).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    #endregion
+
     #region String.Equals
 
     [TestMethod]
@@ -89,6 +160,17 @@ public partial class QueryGroupTest
     }
 
     [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForConstant()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => string.Equals(e.PropertyString, "A")).GetString(m_dbSetting);
+        var expected = "([PropertyString] = @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
     public void TestQueryGroupParseExpressionStringEqualsForVariable()
     {
         // Setup
@@ -96,6 +178,20 @@ public partial class QueryGroupTest
 
         // Act
         var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString.Equals(value)).GetString(m_dbSetting);
+        var expected = "([PropertyString] = @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForVariable()
+    {
+        // Setup
+        var value = "A";
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => string.Equals(e.PropertyString, value)).GetString(m_dbSetting);
         var expected = "([PropertyString] = @PropertyString)";
 
         // Assert
@@ -120,10 +216,38 @@ public partial class QueryGroupTest
     }
 
     [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForClassProperty()
+    {
+        // Setup
+        var value = new QueryGroupTestExpressionClass
+        {
+            PropertyString = "A"
+        };
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => string.Equals(e.PropertyString, value.PropertyString)).GetString(m_dbSetting);
+        var expected = "([PropertyString] = @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
     public void TestQueryGroupParseExpressionStringEqualsForMethodCall()
     {
         // Act
         var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString.Equals(GetStringValueForParseExpression())).GetString(m_dbSetting);
+        var expected = "([PropertyString] = @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForMethodCall()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => string.Equals(e.PropertyString, GetStringValueForParseExpression())).GetString(m_dbSetting);
         var expected = "([PropertyString] = @PropertyString)";
 
         // Assert
@@ -139,6 +263,158 @@ public partial class QueryGroupTest
         // Act
         var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => e.PropertyString.Equals(value)).GetString(m_dbSetting);
         var expected = "([PropertyString] = @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForVariableMethodCall()
+    {
+        // Setup
+        var value = GetStringValueForParseExpression();
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => string.Equals(e.PropertyString, value)).GetString(m_dbSetting);
+        var expected = "([PropertyString] = @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    #endregion
+
+    #region Not String.Equals
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsForConstantNot()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !e.PropertyString.Equals("A")).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForConstantNot()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !string.Equals(e.PropertyString, "A")).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsForVariableNot()
+    {
+        // Setup
+        var value = "A";
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !e.PropertyString.Equals(value)).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForVariableNot()
+    {
+        // Setup
+        var value = "A";
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !string.Equals(e.PropertyString, value)).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsForClassPropertyNot()
+    {
+        // Setup
+        var value = new QueryGroupTestExpressionClass
+        {
+            PropertyString = "A"
+        };
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !e.PropertyString.Equals(value.PropertyString)).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForClassPropertyNot()
+    {
+        // Setup
+        var value = new QueryGroupTestExpressionClass
+        {
+            PropertyString = "A"
+        };
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !string.Equals(e.PropertyString, value.PropertyString)).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsForMethodCallNot()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !e.PropertyString.Equals(GetStringValueForParseExpression())).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForMethodCallNot()
+    {
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !string.Equals(e.PropertyString, GetStringValueForParseExpression())).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsForVariableMethodCallNot()
+    {
+        // Setup
+        var value = GetStringValueForParseExpression();
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !e.PropertyString.Equals(value)).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
+
+        // Assert
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionStringEqualsStaticForVariableMethodCallNot()
+    {
+        // Setup
+        var value = GetStringValueForParseExpression();
+
+        // Act
+        var actual = QueryGroup.Parse<QueryGroupTestExpressionClass>(e => !string.Equals(e.PropertyString, value)).GetString(m_dbSetting);
+        var expected = "([PropertyString] <> @PropertyString)";
 
         // Assert
         Assert.AreEqual(expected, actual);

--- a/src/RepoDb/Cachers/PropertyMappedNameCache.cs
+++ b/src/RepoDb/Cachers/PropertyMappedNameCache.cs
@@ -100,15 +100,5 @@ public static class PropertyMappedNameCache
     public static void Flush() =>
         cache.Clear();
 
-    /// <summary>
-    /// Generates a hashcode for caching.
-    /// </summary>
-    /// <param name="entityType">The type of the data entity.</param>
-    /// <param name="propertyInfo">The instance of <see cref="PropertyInfo"/>.</param>
-    /// <returns>The generated hashcode.</returns>
-    private static int GenerateHashCode(Type entityType,
-        PropertyInfo propertyInfo) =>
-        TypeExtension.GenerateHashCode(entityType, propertyInfo);
-
     #endregion
 }

--- a/src/RepoDb/Mappers/PropertyHandlerMapper.cs
+++ b/src/RepoDb/Mappers/PropertyHandlerMapper.cs
@@ -590,24 +590,6 @@ public static class PropertyHandlerMapper
     #region Helpers
 
     /// <summary>
-    /// Generates a hashcode for caching.
-    /// </summary>
-    /// <param name="type">The type of the data entity.</param>
-    /// <returns>The generated hashcode.</returns>
-    private static int GenerateHashCode(Type type) =>
-        TypeExtension.GenerateHashCode(type);
-
-    /// <summary>
-    /// Generates a hashcode for caching.
-    /// </summary>
-    /// <param name="entityType">The type of the data entity.</param>
-    /// <param name="propertyInfo">The instance of <see cref="PropertyInfo"/>.</param>
-    /// <returns>The generated hashcode.</returns>
-    private static int GenerateHashCode(Type entityType,
-        PropertyInfo propertyInfo) =>
-        TypeExtension.GenerateHashCode(entityType, propertyInfo);
-
-    /// <summary>
     /// Throws an exception if the type does not implemented the <see cref="IPropertyHandler{TInput, TResult}"/> interface.
     /// </summary>
     private static void Guard([NotNull] Type? type)

--- a/src/RepoDb/QueryField.cs
+++ b/src/RepoDb/QueryField.cs
@@ -408,4 +408,36 @@ public partial class QueryField : IEquatable<QueryField>
     }
 
     #endregion
+
+
+    internal QueryField ApplyNot()
+    {
+        if (GetType() != typeof(QueryField))
+            throw new InvalidOperationException();
+
+        return new QueryField(
+            this.Field,
+            this.Operation switch
+            {
+                Operation.Equal => Operation.NotEqual,
+                Operation.NotEqual => Operation.Equal,
+                Operation.Between => Operation.NotBetween,
+                Operation.NotBetween => Operation.Between,
+                Operation.In => Operation.NotIn,
+                Operation.NotIn => Operation.In,
+                Operation.IsNull => Operation.IsNotNull,
+                Operation.IsNotNull => Operation.IsNull,
+                Operation.Like => Operation.NotLike,
+                Operation.NotLike => Operation.Like,
+                Operation.LessThan => Operation.GreaterThanOrEqual,
+                Operation.LessThanOrEqual => Operation.GreaterThan,
+                Operation.GreaterThan => Operation.LessThanOrEqual,
+                Operation.GreaterThanOrEqual => Operation.LessThan,
+                _ => throw new NotSupportedException($"The '{Operation.GetText()}' operation is not invertable.")
+            },
+            this.Parameter.Value,
+            this.Parameter.DbType,
+            false);
+    }
+
 }


### PR DESCRIPTION
Attempt at fixing issue #26, and at the same time support string.Equals(v1, v2) in C#.