### PR TITLE
Implement common conversion support via IParsable<> and IFormattable …

### DIFF
--- a/src/RepoDb.Core.UnitTests/QueryGroups/QueryGroupParseJsonExpressions.cs
+++ b/src/RepoDb.Core.UnitTests/QueryGroups/QueryGroupParseJsonExpressions.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Identity.Client;
+
+namespace RepoDb.UnitTests;
+
+public partial class QueryGroupTest
+{
+    public record class ForJsonEntity
+    {
+        public int Id { get; set; }
+        public DbJsonValue<JsonData> Data { get; set; }
+        public DbJsonValue<JsonData>? DataNull { get; set; }
+    }
+
+    public record class JsonData
+    {
+        public int? Nr { get; set; }
+        public string? Name { get; set; }
+        public string[]? Values { get; set; }
+
+        public JsonData? Inner { get; set; }
+    }
+
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionJsonExtract()
+    {
+        var actual = QueryGroup.Parse<ForJsonEntity>(e => e.Data.ExtractValue(x => x.Name) == "a");
+        Assert.AreEqual("(JSON_EXTRACT([Data], '$.Name') = @Data)", actual.GetString(m_dbSetting));
+    }
+
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionJsonValue()
+    {
+        var actual = QueryGroup.Parse<ForJsonEntity>(e => e.Data.Value.Name == "a");
+        Assert.AreEqual("(JSON_EXTRACT([Data], '$.Name') = @Data)", actual.GetString(m_dbSetting));
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionJsonExtract2()
+    {
+        var actual = QueryGroup.Parse<ForJsonEntity>(e => e.Data.ExtractValue(x => x.Name) == "a" && e.Data.ExtractValue(x => x.Nr) == 7);
+        Assert.AreEqual("((JSON_EXTRACT([Data], '$.Name') = @Data) AND (JSON_EXTRACT([Data], '$.Nr') = @Data_1))", actual.GetString(m_dbSetting));
+    }
+
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionJsonValue2()
+    {
+        var actual = QueryGroup.Parse<ForJsonEntity>(e => e.Data.Value.Name == "a" && e.Data.Value.Nr == 2);
+        Assert.AreEqual("((JSON_EXTRACT([Data], '$.Name') = @Data) AND (JSON_EXTRACT([Data], '$.Nr') = @Data_1))", actual.GetString(m_dbSetting));
+    }
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionJsonExtractDeep()
+    {
+        var actual = QueryGroup.Parse<ForJsonEntity>(e => e.Data.ExtractValue(x => x.Values[0]) == "a" && e.Data.ExtractValue(x => x.Inner.Inner.Nr) == 7);
+        Assert.AreEqual("((JSON_EXTRACT([Data], '$.Values[0]') = @Data) AND (JSON_EXTRACT([Data], '$.Inner.Inner.Nr') = @Data_1))", actual.GetString(m_dbSetting));
+    }
+
+
+    [TestMethod]
+    public void TestQueryGroupParseExpressionJsonValueDeep2()
+    {
+        var actual = QueryGroup.Parse<ForJsonEntity>(e => e.Data.Value.Values[0] == "a" && e.Data.Value.Inner.Inner.Nr == 2);
+        Assert.AreEqual("((JSON_EXTRACT([Data], '$.Values[0]') = @Data) AND (JSON_EXTRACT([Data], '$.Inner.Inner.Nr') = @Data_1))", actual.GetString(m_dbSetting));
+    }
+
+}

--- a/src/RepoDb.PostgreSql/DbHelpers/PostgreSqlDbHelper.cs
+++ b/src/RepoDb.PostgreSql/DbHelpers/PostgreSqlDbHelper.cs
@@ -276,6 +276,11 @@ public sealed class PostgreSqlDbHelper : BaseDbHelper
             parameter.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Json;
             parameter.Value = jn.ToJsonString(Converter.JsonSerializerOptions);
         }
+        else if (parameter.Value is IDbJsonValue jv)
+        {
+            parameter.NpgsqlDbType = NpgsqlTypes.NpgsqlDbType.Json;
+            parameter.Value = jv.JsonNode?.ToJsonString(Converter.JsonSerializerOptions);
+        }
     }
 
     #endregion

--- a/src/RepoDb.TestCore/JsonTestsBase.cs
+++ b/src/RepoDb.TestCore/JsonTestsBase.cs
@@ -1,7 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
-using System.Text.Json;
 using System.Text.Json.Nodes;
-using RepoDb.DbSettings;
 using RepoDb.Schema;
 using RepoDb.StatementBuilders;
 using RepoDb.Trace;
@@ -13,7 +11,7 @@ public abstract class JsonTestsBase<TDbInstance> : DbTestBase<TDbInstance> where
 
     public virtual string? JsonBColumnType => null;
 
-    public class JsonTestClass
+    public record class JsonTestClass
     {
         public int Id { get; set; }
         public string Name { get; set; } = string.Empty;
@@ -143,7 +141,7 @@ public abstract class JsonTestsBase<TDbInstance> : DbTestBase<TDbInstance> where
         Assert.HasCount(1, r);
     }
 
-    class JsonBTestClass
+    public record class JsonBTestClass
     {
         public int Id { get; set; }
         public JsonNode? JsonNode { get; set; }
@@ -179,5 +177,49 @@ public abstract class JsonTestsBase<TDbInstance> : DbTestBase<TDbInstance> where
         var r = await sql.QueryAsync<JsonBTestClass>(where: x => x.JsonNode.ExtractValue<string>("Key") == "Value", trace: new DiagnosticsTracer());
         Assert.HasCount(1, r);
         Assert.AreEqual("{\"Key\":\"Value\"}", r.First().JsonNode.ToJsonString(Converter.JsonSerializerOptions));
+    }
+
+    [Table(nameof(JsonTestClass))]
+    public record class JsonTestClassValues
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DbJsonValue<JsonBTestClass> JsonNode { get; set; }
+        public DbJsonValue<JsonBTestClass>? Object { get; set; }
+        public DbJsonValue<string[]> Array { get; set; }
+    }
+
+    [TestMethod]
+    public async Task CreateUpdateAndFetchJsonValue()
+    {
+        using var sql = await CreateOpenConnectionAsync();
+
+        if (!await sql.SchemaObjectExistsAsync<JsonTestClass>(cancellationToken: TestContext.CancellationToken))
+        {
+            await sql.CreateTableAsync<JsonTestClass>(trace: new DiagnosticsTracer());
+        }
+        else
+        {
+            await sql.TruncateAsync<JsonTestClass>(cancellationToken: TestContext.CancellationToken);
+        }
+
+        await sql.InsertAsync(new JsonTestClassValues
+        {
+            Id = 1,
+            Name = "Test",
+            JsonNode = new JsonBTestClass { Id = 5 },
+            Object = new JsonBTestClass { },
+            Array = new string[] { "a", "b" }
+        });
+
+        var r = await sql.QueryAllAsync<JsonTestClassValues>(trace: new DiagnosticsTracer());
+        Assert.HasCount(1, r);
+
+        r = await sql.QueryAsync<JsonTestClassValues>(v => v.JsonNode.ExtractValue(x => x.Id) == 5, trace: new DiagnosticsTracer());
+        Assert.HasCount(1, r);
+
+
+        r = await sql.QueryAsync<JsonTestClassValues>(v => v.JsonNode.Value.Id == 5, trace: new DiagnosticsTracer());
+        Assert.HasCount(1, r);
     }
 }

--- a/src/RepoDb/Compat.cs
+++ b/src/RepoDb/Compat.cs
@@ -146,6 +146,32 @@ namespace System.Diagnostics.CodeAnalysis
         public bool ReturnValue { get; }
     }
 
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+    internal sealed class MaybeNullWhenAttribute : Attribute
+    {
+        //
+        // Summary:
+        //     Initializes the attribute with the specified return value condition.
+        //
+        // Parameters:
+        //   returnValue:
+        //     The return value condition. If the method returns this value, the associated
+        //     parameter will not be null.
+        public MaybeNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        //
+        // Summary:
+        //     Gets the return value condition.
+        //
+        // Returns:
+        //     The return value condition. If the method returns this value, the associated
+        //     parameter will not be null.
+        public bool ReturnValue { get; }
+    }
+
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]
     internal sealed class DoesNotReturnAttribute : Attribute
     {

--- a/src/RepoDb/Converter.cs
+++ b/src/RepoDb/Converter.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace RepoDb;
 
@@ -179,6 +180,16 @@ public static class Converter
         }
     }
 
+    internal static JsonNode? ToJsonObject<T>(T? value)
+    {
+        return JsonSerializer.SerializeToNode(value, JsonSerializerOptions);
+    }
+
+    internal static T FromJsonToObject<T>(JsonNode? json)
+    {
+        return JsonSerializer.Deserialize<T>(json, Converter.JsonSerializerOptions)!;
+    }
+
 #if !NET
     private static object? EnumTryParse<TEnum>(string value)
         where TEnum : struct, Enum
@@ -191,8 +202,14 @@ public static class Converter
 
     #endregion
 
-    public static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    public static readonly JsonSerializerOptions DefaultJsonSerializerOptions = new()
     {
         WriteIndented = false,
     };
+
+    public static JsonSerializerOptions JsonSerializerOptions => GlobalConfiguration.Options?.JsonSerializerOptions ?? DefaultJsonSerializerOptions;
+
+
+    internal static JsonNodeOptions? JsonNodeOptions => null;
+    internal static JsonDocumentOptions JsonDocumentOptions => default;
 }

--- a/src/RepoDb/DbJsonValue.cs
+++ b/src/RepoDb/DbJsonValue.cs
@@ -1,0 +1,96 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+using RepoDb.Interfaces;
+
+namespace RepoDb;
+
+public struct DbJsonValue<T> : IFormattable, IDbJsonValue
+#if NET
+    , IParsable<DbJsonValue<T>>
+#endif
+    where T : notnull
+{
+    JsonNode? _json;
+    T? _value;
+
+    public JsonNode Json => _json ??= Converter.ToJsonObject(_value)!;
+
+    public T Value => _value ?? (_value = Converter.FromJsonToObject<T>(_json))!;
+
+    JsonNode? IDbJsonValue.JsonNode => Json;
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is JsonNode node)
+            return node.ToJsonString() == Json.ToJsonString();
+        else if (obj is T t)
+            return Value.Equals(t);
+        else if (obj is DbJsonValue<T> vt)
+        {
+            if (vt._json is { } jv)
+                return Equals(jv);
+            else
+                return Equals(vt.Json);
+        }
+
+        return false;
+    }
+
+    public override int GetHashCode() => 1;
+
+    /// <inheritdoc/>
+    public string ToString(string? format, IFormatProvider? formatProvider)
+    {
+        return Json?.ToJsonString(Converter.JsonSerializerOptions);
+    }
+
+    /// <inheritdoc/>
+#pragma warning disable CA1000 // Do not declare static members on generic types
+    public static DbJsonValue<T> Parse(string s, IFormatProvider? provider)
+#pragma warning restore CA1000 // Do not declare static members on generic types
+    {
+        if (TryParse(s, provider, out var v))
+            return v;
+        else
+        {
+            throw new FormatException();
+        }
+    }
+
+    /// <inheritdoc/>
+#pragma warning disable CA1000 // Do not declare static members on generic types
+    public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out DbJsonValue<T> result)
+#pragma warning restore CA1000 // Do not declare static members on generic types
+    {
+        if (string.IsNullOrWhiteSpace(s))
+        {
+            result = default;
+            return false;
+        }
+        try
+        {
+            result = new() { _json = JsonObject.Parse(s, Converter.JsonNodeOptions, Converter.JsonDocumentOptions) };
+            return true;
+
+        }
+        catch (Exception)
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    public override string ToString()
+    {
+        return Json?.ToString() ?? "";
+    }
+
+    public static bool operator==(DbJsonValue<T> v1, DbJsonValue<T> v2) => v1.Equals(v2);
+    public static bool operator!=(DbJsonValue<T> v1, DbJsonValue<T> v2) => !v1.Equals(v2);
+    public static bool operator ==(DbJsonValue<T> v1, JsonNode v2) => v1.Equals(v2);
+    public static bool operator !=(DbJsonValue<T> v1, JsonNode v2) => !v1.Equals(v2);
+    public static bool operator ==(JsonNode v1, DbJsonValue<T> v2) => v2.Equals(v1);
+    public static bool operator !=(JsonNode v1, DbJsonValue<T> v2) => !v2.Equals(v1);
+
+    public static implicit operator DbJsonValue<T>(T value) => new DbJsonValue<T> { _value = value };
+}

--- a/src/RepoDb/Extensions/ExpressionExtension.cs
+++ b/src/RepoDb/Extensions/ExpressionExtension.cs
@@ -371,6 +371,8 @@ public static class ExpressionExtension
 #endif
 
                 return Convert.ChangeType(value, toType, CultureInfo.InvariantCulture);
+            case ExpressionType.Quote:
+                return expression.Operand; // The inner expression is the value
             default:
                 throw new NotSupportedException($"Expression '{expression}' is currently not supported.");
         }

--- a/src/RepoDb/Extensions/JsonQueryExtensions.cs
+++ b/src/RepoDb/Extensions/JsonQueryExtensions.cs
@@ -37,9 +37,14 @@ public static partial class JsonQueryExtensions
         }
     }
 
-    public static TResult? ExtractValue<TEntity, TResult>(this JsonNode jsonNode, Expression<Func<TEntity, TResult>> mapping) where TResult: notnull
+    public static TResult? ExtractValue<TEntity, TResult>(this JsonNode jsonNode, Expression<Func<TEntity, TResult>> mapping) where TResult: notnull where TEntity : notnull
     {
         return ExtractValue<TResult>(jsonNode, JsonExtractQueryField.ParsePath(mapping));
+    }
+
+    public static TResult? ExtractValue<TEntity, TResult>(this DbJsonValue<TEntity> jsonNode, Expression<Func<TEntity, TResult>> mapping) where TResult : notnull where TEntity : notnull
+    {
+        return ExtractValue<TResult>(jsonNode.Json, JsonExtractQueryField.ParsePath(mapping));
     }
 
     private static JsonNode? NavigateJsonPath(JsonNode node, string path)

--- a/src/RepoDb/Extensions/QueryFields/JsonExtractQueryField.cs
+++ b/src/RepoDb/Extensions/QueryFields/JsonExtractQueryField.cs
@@ -214,6 +214,9 @@ public sealed partial class JsonExtractQueryField : FunctionalQueryField
             if (string.IsNullOrEmpty(name))
                 return;
 
+            if (Converter.JsonSerializerOptions.PropertyNamingPolicy is {} cn)
+                name = cn.ConvertName(name);
+
             if (sb.Length > 0)
                 sb.Append('.');
             sb.Append(name);

--- a/src/RepoDb/Interfaces/IDbJsonValue.cs
+++ b/src/RepoDb/Interfaces/IDbJsonValue.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Nodes;
+
+namespace RepoDb.Interfaces;
+
+public interface IDbJsonValue
+{
+    JsonNode? JsonNode { get; }
+}

--- a/src/RepoDb/Options/GlobalConfigurationOptions.cs
+++ b/src/RepoDb/Options/GlobalConfigurationOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Data;
 using System.Data.Common;
+using System.Text.Json;
 using RepoDb.Enumerations;
 
 namespace RepoDb.Options;
@@ -7,35 +8,35 @@ namespace RepoDb.Options;
 /// <summary>
 /// A class that is being used to define the globalized configurations for the application.
 /// </summary>
-public record GlobalConfigurationOptions
+public sealed record GlobalConfigurationOptions
 {
     /// <summary>
-    /// Gets or sets the handling of invalid enum values when converting an instance of <see cref="DbDataReader"/> into .NET enum values
+    /// Gets or initializes the handling of invalid enum values when converting an instance of <see cref="DbDataReader"/> into .NET enum values
     /// </summary>
     public InvalidEnumValueHandling EnumHandling { get; init; } = InvalidEnumValueHandling.ThrowError;
 
     /// <summary>
-    /// Gets or sets the value that defines how <c>null</c> is handled in linq style expressions
+    /// Gets or initializes the value that defines how <c>null</c> is handled in linq style expressions
     /// </summary>
     public ExpressionNullSemantics ExpressionNullSemantics { get; init; } = ExpressionNullSemantics.SqlNull;
 
     /// <summary>
-    /// Gets or sets the default value of the batch operation size. The value defines on this property mainly affects the batch size of the InsertAll, MergeAll and UpdateAll operations.
+    /// Gets or initializes the default value of the batch operation size. The value defines on this property mainly affects the batch size of the InsertAll, MergeAll and UpdateAll operations.
     /// </summary>
     public int DefaultBatchOperationSize { get; init; } // = 0;
 
     /// <summary>
-    /// Gets of sets the default value of the cache expiration in minutes.
+    /// Gets of initializes the default value of the cache expiration in minutes.
     /// </summary>
     public int DefaultCacheItemExpirationInMinutes { get; init; } = Constant.DefaultCacheItemExpirationInMinutes;
 
     /// <summary>
-    /// Gets or sets the default equivalent <see cref="DbType"/> of an enumeration if it is being used as a parameter to the execution of any non-entity-based operations.
+    /// Gets or initializes the default equivalent <see cref="DbType"/> of an enumeration if it is being used as a parameter to the execution of any non-entity-based operations.
     /// </summary>
     public DbType EnumDefaultDatabaseType { get; init; } = DbType.String;
 
     /// <summary>
-    /// Gets or sets the default value of how the push operations (i.e.: Insert, InsertAll, Merge and MergeAll) behaves when returning the value from the key columns (i.e.: Primary and Identity).
+    /// Gets or initializes the default value of how the push operations (i.e.: Insert, InsertAll, Merge and MergeAll) behaves when returning the value from the key columns (i.e.: Primary and Identity).
     /// </summary>
     public KeyColumnReturnBehavior KeyColumnReturnBehavior { get; init; } = KeyColumnReturnBehavior.IdentityOrElsePrimary;
 
@@ -50,4 +51,9 @@ public record GlobalConfigurationOptions
     /// Enable the support for the SQL Server's <c>IDENTITY_INSERT</c> feature. This allows the insertion of explicit values into identity columns.
     /// </summary>
     public bool SqlServerIdentityInsert { get; init; }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public JsonSerializerOptions JsonSerializerOptions { get; init; } = Converter.DefaultJsonSerializerOptions;
 }

--- a/src/RepoDb/QueryGroup/ParseExpression.cs
+++ b/src/RepoDb/QueryGroup/ParseExpression.cs
@@ -19,11 +19,11 @@ public partial class QueryGroup
     /// </summary>
     /// <param name="expression"></param>
     /// <returns></returns>
-    private static bool IsDirect(BinaryExpression expression) =>
+    private static bool IsDirect<TEntity>(BinaryExpression expression) =>
         (
             expression.Left.NodeType == ExpressionType.Constant ||
             expression.Left.NodeType == ExpressionType.Convert ||
-            (expression.Left is MemberExpression meLeft && meLeft.NodeType == ExpressionType.MemberAccess && meLeft.Expression?.Type.IsClassType() == true)
+            (expression.Left is MemberExpression meLeft && meLeft.NodeType == ExpressionType.MemberAccess && meLeft.Expression is ParameterExpression && meLeft.Expression?.Type == typeof(TEntity))
         )
         &&
         (
@@ -129,7 +129,10 @@ public partial class QueryGroup
         where TEntity : class
     {
         // Check directness (column-to-value, value-to-column, etc.)
-        if (IsDirect(expression))
+
+        bool isSimpleCheck = expression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual or ExpressionType.LessThan or ExpressionType.LessThanOrEqual or ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual;
+
+        if (IsDirect<TEntity>(expression))
         {
             // Column-to-column comparison: both sides are member accesses on the parameter
             if (expression.Left is MemberExpression leftMember && leftMember.Expression is ParameterExpression &&
@@ -149,7 +152,7 @@ public partial class QueryGroup
         }
         else if (expression.Left is MethodCallExpression m
             && expression.Right is ConstantExpression c && c.Value is int intVal && intVal == 0
-            && expression.NodeType is ExpressionType.Equal or ExpressionType.NotEqual or ExpressionType.LessThan or ExpressionType.LessThanOrEqual or ExpressionType.GreaterThan or ExpressionType.GreaterThanOrEqual
+            && isSimpleCheck
             && ((m.Method.Name is nameof(string.Compare) or nameof(string.CompareTo) && m.Method.DeclaringType == StaticType.String) || m.Method == VBCompareString.Value))
         {
             var propExpr = m.Object is { } ob ? ob : m.Arguments[0];
@@ -170,10 +173,11 @@ public partial class QueryGroup
         }
         else if (expression.Left is MethodCallExpression m2
             && m2.Method.Name is nameof(JsonQueryExtensions.ExtractValue) && m2.Method.DeclaringType == typeof(JsonQueryExtensions)
+            && isSimpleCheck
             && QueryField.GetProperty<TEntity>(m2.Arguments[0]) is { } propExpr)
         {
             var pathArg = m2.Arguments[1];
-            var jsonPath =  pathArg is { NodeType: ExpressionType.Quote } ? JsonExtractQueryField.ParsePath(((UnaryExpression)pathArg).Operand) : pathArg.GetValue() as string;
+            var jsonPath = pathArg is { NodeType: ExpressionType.Quote } ? JsonExtractQueryField.ParsePath(((UnaryExpression)pathArg).Operand) : pathArg.GetValue() as string;
             ArgumentNullException.ThrowIfNull(jsonPath);
             var vv = QueryField.Parse<TEntity>(expression).GetFields(false)!.Single();
 
@@ -183,6 +187,7 @@ public partial class QueryGroup
             && m3.Object is { }
             && m3.Method.DeclaringType == StaticType.String
             && m3.Method.Name is nameof(string.Trim) or nameof(string.TrimStart) or nameof(string.TrimEnd) or nameof(string.ToUpper) or nameof(string.ToLower) or nameof(string.ToUpperInvariant) or nameof(string.ToLowerInvariant)
+            && isSimpleCheck
             && QueryField.GetProperty<TEntity>(m3.Object) is { } propExpr3)
         {
             var value = expression.Right.GetValue();
@@ -203,9 +208,15 @@ public partial class QueryGroup
             && m4.Expression is { }
             && m4.Member.DeclaringType == StaticType.String
             && m4.Member.Name is nameof(string.Length)
+            && isSimpleCheck
             && QueryField.GetProperty<TEntity>(m4.Expression) is { } propExpr4)
         {
             return new QueryGroup(new LengthQueryField(propExpr4.AsField().FieldName, QueryField.GetOperation(expression.NodeType), expression.Right.GetValue()).AsEnumerable());
+        }
+        else if (isSimpleCheck
+            && GetJsonExtractFromPath<TEntity>(expression.Left) is { FieldName: not null, Path: not null } jsonExtract)
+        {
+            return new QueryGroup([new JsonExtractQueryField(jsonExtract.FieldName, jsonExtract.Path, expression.Right.GetValue(), dbType: ClientTypeToDbTypeResolver.Instance.Resolve(expression.Right.Type))]);
         }
 
         // Otherwise, recursively parse as before (for AndAlso, OrElse, etc.)
@@ -229,6 +240,54 @@ public partial class QueryGroup
         // Return the left query group, which is now modified to include the right side
         return leftQueryGroup;
     }
+
+    sealed class ReplaceVisitor : ExpressionVisitor
+    {
+        private readonly Expression _from;
+        private readonly Expression _to;
+
+        public ReplaceVisitor(Expression from, Expression to)
+        {
+            _from = from;
+            _to = to;
+        }
+
+        public override Expression? Visit(Expression? node)
+        {
+            return node == _from ? _to : base.Visit(node);
+        }
+    }
+
+
+    private static (string? FieldName, string? Path) GetJsonExtractFromPath<TEntity>(Expression left) where TEntity : class
+    {
+        var e = left;
+        Expression path;
+
+        while (e != null)
+        {
+            Expression? next;
+            if (e is MemberExpression me)
+                next = me.Expression;
+            else if (e is BinaryExpression be && be.NodeType == ExpressionType.ArrayIndex)
+                next = be.Left;
+            else
+                return (null, null);
+
+            if (next is MemberExpression p && p.Member.DeclaringType?.IsGenericType == true && p.Member.DeclaringType.GetGenericTypeDefinition() == typeof(DbJsonValue<>))
+            {
+                var arg = Expression.Parameter(p.Member.DeclaringType.GetGenericArguments()[0], "e");
+                path = new ReplaceVisitor(next, arg).Visit(left)!;
+
+                return (p.Expression is { } ? QueryField.GetProperty<TEntity>(p.Expression)?.FieldName : null, JsonExtractQueryField.ParsePath(Expression.Lambda(path, arg)));
+            }
+            e = next;
+        }
+
+        return (null, null);
+    }
+
+
 
     /*
      * Unary

--- a/src/RepoDb/Reflection/Compiler.cs
+++ b/src/RepoDb/Reflection/Compiler.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using RepoDb.DbSettings;
@@ -599,7 +600,9 @@ internal sealed partial class Compiler
                 result = Expression.Convert(result, Enum.GetUnderlyingType(underlyingFromType));
 
                 if (result.Type != underlyingToType)
+                {
                     result = Expression.Convert(result, underlyingToType);
+                }
             }
             else if (underlyingToType == StaticType.Decimal)
             {
@@ -607,20 +610,24 @@ internal sealed partial class Compiler
                 result = Expression.Convert(result, Enum.GetUnderlyingType(underlyingFromType));
 
                 if (result.Type != underlyingToType)
+                {
                     result = Expression.Convert(result, underlyingToType);
+                }
             }
             else
             {
                 return result; // Will fail
             }
         }
-        else if (toType == StaticType.String && fromType == StaticType.DateTime)
+        else if (toType == StaticType.String && underlyingFromType == StaticType.DateTime)
         {
-            result = Expression.Call(GetMethodInfo(() => StrictToString(DateTime.MinValue)), result);
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+            result = Expression.Call(GetMethodInfo(() => StrictToString(DateTime.MinValue)), expr);
         }
-        else if (toType == StaticType.String && fromType == StaticType.DateTimeOffset)
+        else if (toType == StaticType.String && underlyingFromType == StaticType.DateTimeOffset)
         {
-            result = Expression.Call(GetMethodInfo(() => StrictToString(DateTimeOffset.MinValue)), result);
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+            result = Expression.Call(GetMethodInfo(() => StrictToString(DateTimeOffset.MinValue)), expr);
         }
         else if (toType == StaticType.String && fromType.IsJsonNode())
         {
@@ -631,16 +638,22 @@ internal sealed partial class Compiler
             result = Expression.Call(GetMethodInfo(() => JsonNode.Parse("", nodeOptions: null, documentOptions: default)), [result, Expression.Default(typeof(JsonNodeOptions?)), Expression.Default(typeof(JsonDocumentOptions))]);
 
             if (result.Type != toType)
+            {
                 result = Expression.Convert(result, toType);
+            }
         }
 #if NET
-        else if (toType == StaticType.String && fromType == StaticType.DateOnly)
+        else if (toType == StaticType.String && underlyingFromType == StaticType.DateOnly)
         {
-            result = Expression.Call(GetMethodInfo(() => StrictToString(DateOnly.MinValue)), result);
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+
+            result = Expression.Call(GetMethodInfo(() => StrictToString(DateOnly.MinValue)), expr);
         }
-        else if (toType == StaticType.String && fromType == StaticType.TimeOnly)
+        else if (toType == StaticType.String && underlyingFromType == StaticType.TimeOnly)
         {
-            result = Expression.Call(GetMethodInfo(() => StrictToString(TimeOnly.MinValue)), result);
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+
+            result = Expression.Call(GetMethodInfo(() => StrictToString(TimeOnly.MinValue)), expr);
         }
 #endif
         else if (underlyingToType == StaticType.DateTime && underlyingFromType == StaticType.DateTimeOffset)
@@ -651,9 +664,49 @@ internal sealed partial class Compiler
         {
             result = Expression.New(typeof(DateTimeOffset).GetConstructor([typeof(DateTime)])!, [result]);
         }
-        else if (underlyingToType == StaticType.Boolean && underlyingFromType == StaticType.String)
+        else if (underlyingToType == StaticType.Boolean && fromType == StaticType.String)
         {
             result = Expression.Call(GetMethodInfo(() => StrictParseBoolean(null)), expression);
+        }
+        else if (fromType == StaticType.String && underlyingToType == StaticType.Decimal)
+        {
+            result = Expression.Call(GetMethodInfo(() => StrictParseDecimal(null!)), expression);
+        }
+        else if (fromType == StaticType.String && underlyingToType == StaticType.DateTime)
+        {
+            result = Expression.Call(GetMethodInfo(() => StrictParseDateTime(null!)), expression);
+        }
+        else if (fromType == StaticType.String && underlyingToType == StaticType.DateTimeOffset)
+        {
+            result = Expression.Call(GetMethodInfo(() => StrictParseDateTimeOffset(null!)), expression);
+        }
+#if NET
+        else if (fromType == StaticType.String && underlyingToType == typeof(DateOnly))
+        {
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+            result = Expression.Call(GetMethodInfo(() => StrictParseDateOnly(null!)), expr);
+        }
+        else if (fromType == StaticType.String && underlyingToType == typeof(TimeOnly))
+        {
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+            result = Expression.Call(GetMethodInfo(() => StrictParseTimeOnly(null!)), expr);
+        }
+        else if (fromType == typeof(string) && underlyingToType.IsAssignableTo(typeof(IParsable<>).MakeGenericType(underlyingToType)))
+#else
+        else if (fromType == typeof(string) && underlyingToType.IsGenericType && underlyingToType.GetGenericTypeDefinition() == typeof(DbJsonValue<>))
+#endif
+        {
+            var parseMethod = underlyingToType.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, binder: null, callConvention: default, [typeof(string), typeof(IFormatProvider)], null)!;
+            result = Expression.Call(parseMethod, expression, Expression.Constant(CultureInfo.InvariantCulture));
+        }
+        else if (toType == typeof(string) && typeof(IFormattable).IsAssignableFrom(underlyingFromType))
+        {
+            var toStringMethod = GetMethodInfo<IFormattable>(x => x.ToString(null, null));
+
+            var expr = (fromType == underlyingFromType) ? expression : Expression.Convert(expression, underlyingFromType);
+            expr = Expression.Convert(expr, typeof(IFormattable));
+
+            result = Expression.Call(expr, toStringMethod, Expression.Constant(null, typeof(string)), Expression.Constant(CultureInfo.InvariantCulture, typeof(IFormatProvider)));
         }
         else if (GetSystemConvertToTypeMethod(underlyingFromType, underlyingToType) is { } methodInfo)
         {
@@ -666,35 +719,6 @@ internal sealed partial class Compiler
                 ConvertExpressionToTypeExpression(result, StaticType.Object),
                 Expression.Constant(TypeCache.Get(underlyingToType).UnderlyingType)
             ]);
-        }
-        else if (underlyingFromType == StaticType.String)
-        {
-            if (underlyingToType == StaticType.Decimal)
-            {
-                result = Expression.Call(GetMethodInfo(() => StrictParseDecimal(null!)), expression);
-            }
-            else if (underlyingToType == StaticType.DateTime)
-            {
-                result = Expression.Call(GetMethodInfo(() => StrictParseDateTime(null!)), expression);
-            }
-            else if (underlyingToType == StaticType.DateTimeOffset)
-            {
-                result = Expression.Call(GetMethodInfo(() => StrictParseDateTimeOffset(null!)), expression);
-            }
-#if NET
-            else if (underlyingToType == typeof(DateOnly))
-            {
-                result = Expression.Call(GetMethodInfo(() => StrictParseDateOnly(null!)), expression);
-            }
-            else if (underlyingToType == typeof(TimeOnly))
-            {
-                result = Expression.Call(GetMethodInfo(() => StrictParseTimeOnly(null!)), expression);
-            }
-#endif
-            else
-            {
-                return result; // Will fail
-            }
         }
         else
         {


### PR DESCRIPTION
Implement common conversion support via IParsable<> and IFormattable for DotNet 7+. 

Use this for an easier to use
Json api via DbJsonValue<>
(and add fallback support for this specific for older versions)

Route more system type conversions via specialized optimized code paths.