### PR TITLE
Add passthrough type registry to skip conversion for provider-handled types

### DIFF
--- a/src/RepoDb.PostgreSql/PostgreSqlGlobalConfiguration.cs
+++ b/src/RepoDb.PostgreSql/PostgreSqlGlobalConfiguration.cs
@@ -17,4 +17,45 @@ public static partial class PostgreSqlGlobalConfiguration
         PostgreSqlBootstrap.InitializeInternal();
         return globalConfiguration;
     }
+
+    /// <summary>
+    /// Registers all NodaTime types as passthrough so that RepoDb does not
+    /// attempt to convert them. Npgsql handles these natively when the
+    /// data source is configured with UseNodaTime().
+    /// Call after UsePostgreSql():
+    /// <code>GlobalConfiguration.Setup().UsePostgreSql().UseNodaTime();</code>
+    /// </summary>
+    /// <param name="globalConfiguration">The instance of the global configuration in used.</param>
+    /// <returns>The used global configuration instance itself.</returns>
+    public static GlobalConfiguration UseNodaTime(this GlobalConfiguration globalConfiguration)
+    {
+        // All NodaTime types that Npgsql maps via UseNodaTime():
+        // https://www.npgsql.org/doc/types/nodatime.html
+        // Resolved by name to avoid a hard dependency on the NodaTime package.
+        var nodaTimeTypes = new[]
+        {
+            "NodaTime.Instant",
+            "NodaTime.LocalDate",
+            "NodaTime.LocalTime",
+            "NodaTime.LocalDateTime",
+            "NodaTime.ZonedDateTime",
+            "NodaTime.OffsetDateTime",
+            "NodaTime.OffsetTime",
+            "NodaTime.Period",
+            "NodaTime.Duration",
+            "NodaTime.DateInterval",
+            "NodaTime.Interval",
+        };
+
+        foreach (var typeName in nodaTimeTypes)
+        {
+            var type = Type.GetType($"{typeName}, NodaTime");
+            if (type is not null)
+            {
+                TypeMapper.AddPassthrough(type);
+            }
+        }
+
+        return globalConfiguration;
+    }
 }

--- a/src/RepoDb/DbSettings/BaseDbHelper.cs
+++ b/src/RepoDb/DbSettings/BaseDbHelper.cs
@@ -137,7 +137,8 @@ public abstract class BaseDbHelper : IDbHelper
     /// <returns>The converted value.</returns>
     public virtual object? ParameterValueToDb(object? value, IDbDataParameter parameter)
     {
-        if (value is IFormattable f && value.GetType().HandleAsStringForDB())
+        if (value is IFormattable f && value.GetType() is { } vt
+            && vt.HandleAsStringForDB() && !TypeMapper.IsPassthrough(vt))
         {
             return f.ToString(null, CultureInfo.InvariantCulture);
         }

--- a/src/RepoDb/Extensions/DbCommandExtension.cs
+++ b/src/RepoDb/Extensions/DbCommandExtension.cs
@@ -692,6 +692,10 @@ public static class DbCommandExtension
 
             if (dbFieldType != valueType)
             {
+                // Skip conversion for types registered as provider-handled
+                if (TypeMapper.IsPassthrough(valueType))
+                    return false;
+
                 if (value is not null)
                 {
                     value = AutomaticConvert(value, valueType, dbFieldType);

--- a/src/RepoDb/Mappers/TypeMapper.cs
+++ b/src/RepoDb/Mappers/TypeMapper.cs
@@ -16,6 +16,38 @@ public static class TypeMapper
 
     private static readonly ConcurrentDictionary<Type, DbType> typeMaps = new();
     private static readonly ConcurrentDictionary<(Type, PropertyInfo PropertyInfo), DbType> propertyMaps = new();
+    private static readonly ConcurrentDictionary<Type, bool> passthroughTypes = new();
+
+    #endregion
+
+    #region Passthrough
+
+    /// <summary>
+    /// Registers a type as provider-handled. RepoDb will not attempt to convert
+    /// values of this type, passing them directly to the ADO.NET provider.
+    /// Use this for types handled by provider plugins (e.g. NodaTime types
+    /// with Npgsql's UseNodaTime()).
+    /// </summary>
+    /// <typeparam name="TType">The type to pass through without conversion.</typeparam>
+    public static void AddPassthrough<TType>() =>
+        AddPassthrough(typeof(TType));
+
+    /// <summary>
+    /// Registers a type as provider-handled. RepoDb will not attempt to convert
+    /// values of this type, passing them directly to the ADO.NET provider.
+    /// </summary>
+    /// <param name="type">The type to pass through without conversion.</param>
+    public static void AddPassthrough(Type type)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        passthroughTypes[type] = true;
+    }
+
+    /// <summary>
+    /// Returns true if the type has been registered as a passthrough type.
+    /// </summary>
+    internal static bool IsPassthrough(Type type) =>
+        passthroughTypes.ContainsKey(type);
 
     #endregion
 

--- a/src/RepoDb/Reflection/Compiler.cs
+++ b/src/RepoDb/Reflection/Compiler.cs
@@ -773,6 +773,10 @@ internal sealed partial class Compiler
         {
             return Expression.Convert(expression, underlyingToType);
         }
+        else if (TypeMapper.IsPassthrough(underlyingFromType))
+        {
+            // Registered passthrough type — skip conversion, let the provider handle it
+        }
         else
         {
             return ConvertExpressionToSystemConvertExpression();


### PR DESCRIPTION
Fixes #41

## Problem

Since 3424b01, the type conversion pipeline converts all property values to match the DB schema type. This breaks ADO.NET provider type plugins where the provider handles types natively (e.g. Npgsql with `UseNodaTime()` for NodaTime types like `LocalDate` and `Instant`).

The conversion fails in three separate code paths:
- `BaseDbHelper.ParameterValueToDb` converts non-System value types to strings via `HandleAsStringForDB`
- `Compiler.ConvertExpressionWithAutomaticConversion` tries to build coercion expressions that don't exist (`LocalDate` -> `DateOnly`)
- `DbCommandExtension.AutomaticConvert` falls through to `Convert.ChangeType` which requires `IConvertible`

I looked at fixing this just in the PostgreSQL-specific code (per your suggestion on #41), but that only solves the `ParameterValueToDb` path. The Compiler and `DbCommandExtension` paths are in the core RepoDb library and still need changes. Rather than adding type-specific hacks in each path, a passthrough registry keeps the fix in one place and lets all three paths check the same thing.

## Solution

Add `TypeMapper.AddPassthrough<T>()` for registering types that the ADO.NET provider handles natively. Registered types skip conversion in all three paths. No changes to existing behaviour for unregistered types.

For PostgreSQL + NodaTime, there's a convenience method that registers all 11 mapped NodaTime types in one call:

```csharp
GlobalConfiguration.Setup().UsePostgreSql().UseNodaTime();
```

This mirrors Npgsql's own `UseNodaTime()` pattern. The types are resolved by name via `Type.GetType()` so there's no hard dependency on the NodaTime package. If NodaTime isn't loaded, the registrations are silently skipped.

The same `AddPassthrough` mechanism works for any other provider plugin types (NetTopologySuite, etc.) without RepoDb needing to know about them.

## Changes

- `TypeMapper.cs` - `AddPassthrough<T>()`, `AddPassthrough(Type)`, `IsPassthrough(Type)`
- `BaseDbHelper.cs` - skip `HandleAsStringForDB` for passthrough types
- `Compiler.cs` - skip `ConvertExpressionToSystemConvertExpression` for passthrough types
- `DbCommandExtension.cs` - skip `AutomaticConvert` for passthrough types
- `PostgreSqlGlobalConfiguration.cs` - `UseNodaTime()` convenience method

## Test results

NodaTime repro from #41 passes all 5 operations (INSERT, QUERY, READ, MAX, roundtrip) with `UseNodaTime()`.